### PR TITLE
Revert back to iptables based kube-proxy and apply route on restart instead

### DIFF
--- a/ansible/roles/k8s-base/tasks/main.yml
+++ b/ansible/roles/k8s-base/tasks/main.yml
@@ -78,6 +78,15 @@
   tags:
     - k8s
 
+- name: Ensure JSONPath.sh
+  become: yes
+  get_url:
+    url: https://raw.githubusercontent.com/mclarkson/JSONPath.sh/master/JSONPath.sh
+    dest: /usr/bin/JSONPath.sh
+    mode: 0755
+  tags:
+    - k8s
+
 - name: Ensure Docker Group
   group:
     name: docker

--- a/ansible/roles/k8s-master/tasks/main.yml
+++ b/ansible/roles/k8s-master/tasks/main.yml
@@ -31,15 +31,15 @@
     line: 'export KUBECONFIG=/home/ubuntu/admin.conf'
     state: present
 
-- name: Set --proxy-mode flag in kube-proxy daemonset (workaround for https://github.com/kubernetes/kubernetes/issues/34101)
-  become: yes
-  shell: "kubectl --kubeconfig=/home/ubuntu/admin.conf -n kube-system get ds -l 'k8s-app==kube-proxy' -o json | jq '.items[0].spec.template.spec.containers[0].command |= .+ [\"--proxy-mode=userspace\"]' | kubectl --kubeconfig=/home/ubuntu/admin.conf apply -f - && kubectl --kubeconfig=/home/ubuntu/admin.conf -n kube-system delete pods -l 'k8s-app==kube-proxy'"
-  register: proxy
-  until: proxy.rc == 0
-  retries: 60
-  delay: 10
-  tags:
-    - k8s
+#- name: Set --proxy-mode flag in kube-proxy daemonset (workaround for https://github.com/kubernetes/kubernetes/issues/34101)
+#  become: yes
+#  shell: "kubectl --kubeconfig=/home/ubuntu/admin.conf -n kube-system get ds -l 'k8s-app==kube-proxy' -o json | jq '.items[0].spec.template.spec.containers[0].command |= .+ [\"--proxy-mode=userspace\"]' | kubectl --kubeconfig=/home/ubuntu/admin.conf apply -f - && kubectl --kubeconfig=/home/ubuntu/admin.conf -n kube-system delete pods -l 'k8s-app==kube-proxy'"
+#  register: proxy
+#  until: proxy.rc == 0
+#  retries: 60
+#  delay: 10
+#  tags:
+#    - k8s
 
 - name: Ensure Network Start Script
   become: yes


### PR DESCRIPTION
Regarding:
```
+#- name: Set --proxy-mode flag in kube-proxy daemonset (workaround for https://github.com/kubernetes/kubernetes/issues/34101)
```
The problem only surfaces after rebooting k8s2 or k8s3. I think *kubeadm* adds the route with 'route add' or 'ip route add' so it is not persistent.

This patch set gets the kubernetes ClusterIP and k8s1 node IP using *kubectl* (so that it will still l work if either of these values change) and adds the route every time the workers are rebooted.

Also 'fixes' the error:
```
==> k8s1: mesg: 
==> k8s1: ttyname failed
==> k8s1: : 
==> k8s1: Inappropriate ioctl for device
```
